### PR TITLE
fix: linker API integer types

### DIFF
--- a/src/memory_buffer.rs
+++ b/src/memory_buffer.rs
@@ -171,7 +171,7 @@ impl MemoryBuffer {
 
     /// Disassembles the bytecode in the buffer.
     #[cfg(all(feature = "target-eravm", feature = "llvm17-0"))]
-    pub fn disassemble_eravm(&self, machine: &TargetMachine, pc: u32, options: u32) -> Result<Self, LLVMString> {
+    pub fn disassemble_eravm(&self, machine: &TargetMachine, pc: u64, options: u64) -> Result<Self, LLVMString> {
         let mut output_buffer = ptr::null_mut();
         let mut err_string = MaybeUninit::uninit();
 
@@ -210,13 +210,12 @@ impl MemoryBuffer {
         let mut err_string = MaybeUninit::uninit();
 
         let metadata_ptr = metadata.as_ptr() as *const ::libc::c_char;
-        let metadata_size = metadata.len() as libc::c_uint;
 
         let return_code = unsafe {
             LLVMAddMetadataEraVM(
                 self.memory_buffer,
                 metadata_ptr,
-                metadata_size,
+                metadata.len() as u64,
                 &mut output_buffer,
                 err_string.as_mut_ptr(),
             )
@@ -234,7 +233,7 @@ impl MemoryBuffer {
     /// Checks if the bytecode exceeds the EraVM size limit.
     #[cfg(all(feature = "target-eravm", feature = "llvm17-0"))]
     pub fn exceeds_size_limit_eravm(&self, metadata_size: usize) -> bool {
-        let return_code = unsafe { LLVMExceedsSizeLimitEraVM(self.memory_buffer, metadata_size as libc::c_uint) };
+        let return_code = unsafe { LLVMExceedsSizeLimitEraVM(self.memory_buffer, metadata_size as u64) };
 
         return_code != 0
     }
@@ -242,7 +241,7 @@ impl MemoryBuffer {
     /// Returns unresolved symbols in the ELF wrapper.
     #[cfg(all(feature = "target-eravm", feature = "llvm17-0"))]
     pub fn get_undefined_symbols_eravm(&self) -> Vec<String> {
-        let mut output_size = 0;
+        let mut output_size: u64 = 0;
 
         let output_buffer = unsafe { LLVMGetUndefinedLinkerSymbolsEraVM(self.memory_buffer, &mut output_size) };
 
@@ -277,15 +276,13 @@ impl MemoryBuffer {
             .cloned()
             .collect::<Vec<[u8; Self::ETHEREUM_ADDRESS_SIZE]>>();
 
-        let linker_symbols_size = linker_symbols.len() as libc::c_uint;
-
         let return_code = unsafe {
             LLVMLinkEraVM(
                 self.memory_buffer,
                 &mut output_buffer,
                 linker_symbol_keys.as_ptr(),
                 linker_symbol_values.as_ptr() as *const ::libc::c_char,
-                linker_symbols_size,
+                linker_symbols.len() as u64,
                 err_string.as_mut_ptr(),
             )
         };


### PR DESCRIPTION
# What ❔

Fixes some API types by making them 64 bits.

## Why ❔

Most of them turned out to be incorrect.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
